### PR TITLE
Contest folders

### DIFF
--- a/reasoning_models_contest/README.md
+++ b/reasoning_models_contest/README.md
@@ -1,0 +1,16 @@
+# Reasoning Models Contest
+
+**Goal:**  
+Verify the correctness of explanations in an existing MCQA dataset.
+
+**Theme:**  
+"Explanations Under Fire—Fact-Check the MCQA"
+
+**Deliverables:**  
+- Review  
+- Assess  
+- Validate or Correct explanations
+
+**Awards:**  
+- Most Insightful Detective  
+- Speedy Validator

--- a/saq_contest/README.md
+++ b/saq_contest/README.md
@@ -1,0 +1,17 @@
+# Short Answer Question (SAQ) Contest
+
+**Goal:**  
+Generate a high-quality dataset of 2000 SAQs across various cybersecurity domains.
+
+**Theme:**  
+"Stump the AI – CyberSecurity Edition"
+
+**Deliverables:**  
+- Question  
+- Correct Answer  
+- Reference/Explanation  
+- Evaluation Outcome
+
+**Awards:**  
+- Grand Prize for the best "Stumper" question  
+- Category Prizes for best questions in each domain

--- a/unique_dataset_contest/README.md
+++ b/unique_dataset_contest/README.md
@@ -1,0 +1,7 @@
+# Unique Dataset Contest
+
+**Goal:**  
+Create synthetic benchmarks reflecting challenging tasks for cybersecurity professionals.
+
+**Theme:**  
+"Nightmare Tasks No More—Building Mini-Benchmarks for Cybersecurity Pain Points"


### PR DESCRIPTION
This pull request includes the addition of README files for three different contests in the `reasoning_models_contest`, `saq_contest`, and `unique_dataset_contest` directories. These README files provide details about the goals, themes, deliverables, and awards for each contest.

New README files for contests:

* [`reasoning_models_contest/README.md`](diffhunk://#diff-66e41c1caae76c16feb1b6a8583cfd0226dafcf4ae6d10f1d3777a0224810debR1-R16): Added a README file outlining the goal to verify the correctness of explanations in an existing MCQA dataset, the theme "Explanations Under Fire—Fact-Check the MCQA", the deliverables, and the awards.
* [`saq_contest/README.md`](diffhunk://#diff-b21c34eee65edc9b805dd0c80613b727cdab8e319156f58cbf7180d20f0f6e30R1-R17): Added a README file detailing the goal to generate a high-quality dataset of 2000 SAQs across various cybersecurity domains, the theme "Stump the AI – CyberSecurity Edition", the deliverables, and the awards.
* [`unique_dataset_contest/README.md`](diffhunk://#diff-41d1dc1e84b649650b82280194d31dfe1d33f1cf1adb8a650d775c49f2a27ba3R1-R7): Added a README file describing the goal to create synthetic benchmarks reflecting challenging tasks for cybersecurity professionals, and the theme "Nightmare Tasks No More—Building Mini-Benchmarks for Cybersecurity Pain Points".